### PR TITLE
test(mosquitto,nodered): add hashed content check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,6 @@ jobs:
 
       - name: Test Schema Validation Checks for Generated Files
         run: ansible-playbook tests/test_schemas.yml
+      
+      - name: Test Content Checks for Generated Files for Mosquitto / Node-RED
+        run: ansible-playbook tests/test_file_contents.yml

--- a/tests/test_file_contents.yml
+++ b/tests/test_file_contents.yml
@@ -1,0 +1,30 @@
+---
+- name: Test Content for Mosquitto / Node-RED Generated Files
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - "{{ playbook_dir }}/../vars/config.yml"
+  tasks:
+    - name: (Mosquitto) Perform Lookup for Mosquitto Users File
+      ansible.builtin.set_fact:
+        mosquitto_users_file: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/../{{ komponist.deploy_dir }}/mosquitto/users') }}"
+
+    - name: (Mosquitto) Assert that plain-text passwords were encrypted by Docker Container mosquitto-passgen
+      ansible.builtin.assert:
+        that: "{{ mosquitto_users_file | regex_findall(sequence) | count > 0 }}"
+        fail_msg: "FAIL: Docker Container DID NOT encrypt the plain-text passwords for Mosquitto Users file."
+        success_msg: "PASS: Docker Container did encyrpt the plain-text passwords for Mosquitto Users file."
+      vars:
+        sequence: ':\$7\$101\$'
+
+    - name: (Node-RED) Perform Lookup for Node-RED settings.js file
+      ansible.builtin.set_fact:
+        nodered_settings_file: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/../{{ komponist.deploy_dir }}/nodered/settings.js') }}"
+
+    - name: (Node-RED) Assert that Generated passwords for Node-RED are encrypted
+      ansible.builtin.assert:
+        that: "{{ nodered_settings_file | regex_findall(sequence) | count > 0 }}"
+        fail_msg: "FAIL: Jinja2 filter DID NOT encrypt the plain-text passwords for Node-RED settings file."
+        success_msg: "PASS: Jinja2 filter did encyrpt the plain-text passwords for Node-RED settings file."
+      vars:
+        sequence: '\$2b\$08\$'

--- a/tests/test_schemas.yml
+++ b/tests/test_schemas.yml
@@ -6,7 +6,7 @@
   gather_facts: false
   tasks:
     - name: JSON Schema Validation Checks for Compose Services and compose files
-      include_tasks: "{{ playbook_dir }}/services/test_compose_schema.yml"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/services/test_compose_schema.yml"
       with_fileglob:
         - "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/*.yml"
 


### PR DESCRIPTION
- check for mosquitto users where the hashing format for passwords is `$7$101$` for PDKDF_512 encryption
- check for nodered settings where the hashing format is a blowfish encryption and is of the `$2b$08$` format
- fix lint error