### PR TITLE
custom mqtt password filter plugin + fix for Docker Secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore deploy directory
 deploy/
+
+# Python Caches from custom plugins
+__pycache__

--- a/filter_plugins/mosquitto_passwd.py
+++ b/filter_plugins/mosquitto_passwd.py
@@ -1,3 +1,25 @@
+# Komponist - Generate Your Favourite Compose Stack With the Least Effort
+#
+# Copyright (C) 2023  Shantanoo "Shan" Desai <sdes.softdev@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# 
+# mosquitto_passwd.py: Custom Jinja2 filter plugin to generate valid PBKDF2_SHA512
+#                      hash digests for plain-text passwords in `users` file for 
+#                      Eclipse Mosquitto Broker
+
+
 from ansible.errors import AnsibleError
 
 def mosquitto_passwd(passwd):
@@ -15,6 +37,7 @@ def mosquitto_passwd(passwd):
                                         .replace(".", "+")
     
     return digest + "=="
+
 
 class FilterModule(object):
     def filters(self):

--- a/filter_plugins/mosquitto_passwd.py
+++ b/filter_plugins/mosquitto_passwd.py
@@ -1,0 +1,23 @@
+from ansible.errors import AnsibleError
+
+def mosquitto_passwd(passwd):
+    try:
+        import passlib.hash
+    except Exception as e:
+        raise AnsibleError('mosquitto_passlib custom filter requires the passlib pip package installed')
+    
+    SALT_SIZE = 12
+    ITERATIONS = 101
+
+    digest = passlib.hash.pbkdf2_sha512.using(salt_size=SALT_SIZE, rounds=ITERATION) \
+                                        .hash(passwd) \
+                                        .replace("pbkdf2-sha512", "7") \
+                                        .replace(".", "+")
+    
+    return digest + "=="
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'mosquitto_passwd': mosquitto_passwd,
+        }

--- a/filter_plugins/mosquitto_passwd.py
+++ b/filter_plugins/mosquitto_passwd.py
@@ -31,7 +31,7 @@ def mosquitto_passwd(passwd):
     SALT_SIZE = 12
     ITERATIONS = 101
 
-    digest = passlib.hash.pbkdf2_sha512.using(salt_size=SALT_SIZE, rounds=ITERATION) \
+    digest = passlib.hash.pbkdf2_sha512.using(salt_size=SALT_SIZE, rounds=ITERATIONS) \
                                         .hash(passwd) \
                                         .replace("pbkdf2-sha512", "7") \
                                         .replace(".", "+")

--- a/tasks/configure-mosquitto.yml
+++ b/tasks/configure-mosquitto.yml
@@ -37,17 +37,6 @@
         dest: "{{ komponist.deploy_dir }}/mosquitto/users"
         mode: "0755"
 
-    - name: Encrypting the Users file using Mosquitto Docker Container
-      community.docker.docker_container:
-        name: mosquitto-passgen
-        image: "eclipse-mosquitto:{{ komponist.configuration.mosquitto.version }}"
-        state: started
-        command: mosquitto_passwd -U /mosquitto/config/users
-        pull: true
-        volumes:
-          - "{{ komponist.deploy_dir }}/mosquitto/users:/mosquitto/config/users"
-
-
 - name: '(Mosquitto) Generating Access Control List File for Deployment'
   ansible.builtin.template:
     src: "config/mosquitto/acl.j2"

--- a/templates/config/mosquitto/users.j2
+++ b/templates/config/mosquitto/users.j2
@@ -16,5 +16,5 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.#}
 {#- users.j2: Jinja2 Template for Mosquitto Authentication -#}
 {%- for user in credentials.mosquitto.users %}
-{{ user.username }}:{{ user.password }}
+{{ user.username }}:{{ user.password | mosquitto_passwd }}
 {% endfor %}

--- a/templates/services/docker-compose.grafana.yml.j2
+++ b/templates/services/docker-compose.grafana.yml.j2
@@ -34,8 +34,10 @@ services:
       - GF_SERVER_ROOT_URL=/grafana
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
     secrets:
-      - grafana_admin_username
-      - grafana_admin_password
+      - source: grafana_admin_username
+        mode: 0444
+      - source: grafana_admin_password
+        mode: 0444
     logging:
       options:
         max-size: "5m"

--- a/templates/services/docker-compose.influxdbv2.yml.j2
+++ b/templates/services/docker-compose.influxdbv2.yml.j2
@@ -46,9 +46,12 @@ services:
       - "traefik.http.routers.influxdbv2-service=influxdbv2-svc@file"
 {% endif %}
     secrets:
-      - influxdbv2_admin_username
-      - influxdbv2_admin_password
-      - influxdbv2_admin_token
+      - source: influxdbv2_admin_username
+        mode: 0444
+      - source: influxdbv2_admin_password
+        mode: 0444
+      - source: influxdbv2_admin_token
+        mode: 0444
     security_opt:
       - "no-new-privileges:true"
     user: "{{ komponist.uid | default(ansible_user_uid) }}"

--- a/templates/services/docker-compose.timescaledb.yml.j2
+++ b/templates/services/docker-compose.timescaledb.yml.j2
@@ -32,9 +32,12 @@ services:
       - POSTGRES_PASSWORD_FILE=/run/secrets/timescale_admin_password
       - POSTGRES_DB_FILE=/run/secrets/timescale_database
     secrets:
-      - timescale_admin_username
-      - timescale_admin_password
-      - timescale_database
+      - source: timescale_admin_username
+        mode: 0444
+      - source: timescale_admin_password
+        mode: 0444
+      - source: timescale_database
+        mode: 0444
     security_opt:
       - "no-new-privileges:true"
     volumes:

--- a/tests/test_file_contents.yml
+++ b/tests/test_file_contents.yml
@@ -9,11 +9,11 @@
       ansible.builtin.set_fact:
         mosquitto_users_file: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/../{{ komponist.deploy_dir }}/mosquitto/users') }}"
 
-    - name: (Mosquitto) Assert that plain-text passwords were encrypted by Docker Container mosquitto-passgen
+    - name: (Mosquitto) Assert that plain-text passwords were encrypted by Custom Filter mosquitto_passwd
       ansible.builtin.assert:
         that: "{{ mosquitto_users_file | regex_findall(sequence) | count > 0 }}"
-        fail_msg: "FAIL: Docker Container DID NOT encrypt the plain-text passwords for Mosquitto Users file."
-        success_msg: "PASS: Docker Container did encyrpt the plain-text passwords for Mosquitto Users file."
+        fail_msg: "FAIL: Custom Filter mosquitto_passwd DID NOT encrypt the plain-text passwords for Mosquitto Users file."
+        success_msg: "PASS: Custom Filter mosquitto_passwd did encyrpt the plain-text passwords for Mosquitto Users file."
       vars:
         sequence: ':\$7\$101\$'
 


### PR DESCRIPTION
## Tasks

- causing compatibility issues when using Docker Secrets via env vars (fixes #79 )
- create custom mqtt password jinja2 filter for password hashing (closes #85 )