### PR TITLE
chore(ci): add container state test + CI updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,9 +28,6 @@ jobs:
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v3
-      
-      - name: Pull eclipse-mosquitto image
-        run: docker pull eclipse-mosquitto:2.0.15
 
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -41,7 +38,7 @@ jobs:
         run: python -m pip install -r requirements.txt
       
       - name: Install ansible.utils collection
-        run: ansible-galaxy collection install ansible.utils
+        run: ansible-galaxy collection install -r requirements.yml
 
       - name: Generate the Default Komponist Stack
         run: ansible-playbook -vv generate_stack.yml
@@ -57,3 +54,6 @@ jobs:
       
       - name: Test Content Checks for Generated Files for Mosquitto / Node-RED
         run: ansible-playbook tests/test_file_contents.yml
+      
+      - name: Test Containers for Komponist
+        run: ansible-playbook tests/test_compose_containers.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible
 docker
-urllib3 < 2.0 # Pin this requirement to combat a current incompatibility with docker and urllib3
+urllib3
 jsonschema
 passlib

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+collections:
+  - name: community.docker
+    version: 3.4.8
+  - name: ansible.utils
+    version: 2.10.3

--- a/tests/test_compose_containers.yml
+++ b/tests/test_compose_containers.yml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+- name: Bring the Compose Application up and check if containers exist and are running
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - "{{ playbook_dir }}/../vars/config.yml"
+
+  tasks:
+    - name: Container Checks
+      block:
+        - name: (Komponist-Docker) Bring the Compose Application up
+          ansible.builtin.command:
+            cmd: docker compose --project-directory="{{ playbook_dir }}/../deploy" up --quiet-pull -d
+          register: compose_up
+          changed_when: compose_up.rc != 0
+
+        - name: (Komponist-Docker) Obtain information about containers
+          community.docker.docker_container_info:
+            name: "{{ komponist.project_name }}_{{ item }}"
+          register: containers_info
+          loop: "{{ komponist.configuration.keys() }}"
+
+        - name: (Komponist-Docker) Check if containers exist
+          ansible.builtin.assert:
+            that: item.exists
+            fail_msg: "FAIL: {{ item.item }} container DOES NOT EXIST."
+            success_msg: "PASS: {{ item.item }} container EXISTS."
+          loop: "{{ containers_info.results }}"
+          loop_control:
+            label: "{{ item.item }}"
+
+        - name: (Komponist-Docker) Check if containers are running
+          ansible.builtin.assert:
+            that: item.container.State.Status == 'running'
+            fail_msg: "FAIL: {{ item.item }} container NOT RUNNING."
+            success_msg: "PASS: {{ item.item }} container RUNNING."
+          loop: "{{ containers_info.results }}"
+          loop_control:
+            label: "{{ item.item }}"
+
+      always:
+        - name: (Komponist-Docker) docker compose down --volumes
+          ansible.builtin.command:
+            cmd: docker compose --project-directory="{{ playbook_dir }}/../deploy" down --volumes
+          register: compose_down
+          changed_when: compose_down.rc != 0


### PR DESCRIPTION
## Summary

- Closes #101 
- Add `requirements.yml` for installing Ansible Galaxy collections. Update `requirements.txt` test with `urllib3`.
- Cleanup GitHub CI files.
