### PR TITLE
refactor: add default deploy_dir logic + file mode

### DIFF
--- a/.github/workflows/image_build.yml
+++ b/.github/workflows/image_build.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
+
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
 
       - name: Setup QEMU for Multi-Arch images
         uses: docker/setup-qemu-action@v2
-      
+
       - name: setup Docker Buildx for Multi-Arch images
         uses: docker/setup-buildx-action@v2
 
@@ -44,7 +44,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Build and Push Image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,17 @@ on:
 
 jobs:
   lint:
+    name: Ansible Lint
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint Ansible Playbooks / Tasks
-        uses: ansible/ansible-lint-action@v6
+        uses: ansible/ansible-lint@main
         with:
-          path: "./"
+          args: ""
+          setup_python: "true"
+          working_directory: ""
+          requirements_file: "requirements.yml"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,16 +21,15 @@ jobs:
       fail-fast: true
       matrix:
         python-version:
-          - "3.10"
-          - "3.9"
-          - "3.8"
+          - "3.12"
+          - "3.11"
     
     steps:
       - name: Checkout Codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         python-version:
           - "3.12"
           - "3.11"
-    
+
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v4
@@ -32,27 +32,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - name: Install ansible and pip dependencies
         run: python -m pip install -r requirements.txt
-      
+
       - name: Install ansible.utils collection
         run: ansible-galaxy collection install -r requirements.yml
 
       - name: Generate the Default Komponist Stack
         run: ansible-playbook -vv generate_stack.yml
-      
+
       - name: Test Integrity of Generated Directories
         run: ansible-playbook tests/test_generated_directories.yml
-      
+
       - name: Test Integrity of Generated Files
         run: ansible-playbook tests/test_generated_files.yml
 
       - name: Test Schema Validation Checks for Generated Files
         run: ansible-playbook tests/test_schemas.yml
-      
+
       - name: Test Content Checks for Generated Files for Mosquitto / Node-RED
         run: ansible-playbook tests/test_file_contents.yml
-      
+
       - name: Test Containers for Komponist
         run: ansible-playbook tests/test_compose_containers.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,3 @@
+rules:
+  line-length:
+    max: 200

--- a/bootstrap_nodered.yml
+++ b/bootstrap_nodered.yml
@@ -22,6 +22,7 @@
 ---
 - name: Bootstrap Node-RED instance with Database Nodes
   hosts: localhost
+  gather_facts: true
   vars_files:
     - vars/config.yml
     - vars/creds.yml
@@ -72,7 +73,7 @@
 
     - name: (Online) Read `nodes.json` File for Bootstrapping Node-RED
       ansible.builtin.set_fact:
-        external_nodes: "{{ lookup('ansible.builtin.file', '{{ komponist.deploy_dir}}/nodered/nodes.json') }}"
+        external_nodes: "{{ lookup('ansible.builtin.file', '{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered/nodes.json') }}"
       tags: [online]
 
     - name: (Online) Bootstrap Node-RED with External Nodes using nodes.json
@@ -92,7 +93,7 @@
 
     - name: (Offline) Obtain information of External Nodes tarballs
       ansible.builtin.find:
-        paths: "{{ komponist.deploy_dir }}/nodered/"
+        paths: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered/"
         patterns:
           - '*.tgz'
       register: node_tarballs
@@ -101,8 +102,8 @@
     - name: Check for existing tarballs
       ansible.builtin.assert:
         that: "{{ node_tarballs.files | length != 0 }}"
-        fail_msg: "Cannot find any node tarballs with .tgz suffix in {{ komponist.deploy_dir }}/nodered"
-        success_msg: "Found tarballs for external nodes to upload in {{ komponist.deploy_dir }}/nodered"
+        fail_msg: "Cannot find any node tarballs with .tgz suffix in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered"
+        success_msg: "Found tarballs for external nodes to upload in {{ komponist.deploy_dir  | default(ansible_user_dir + '/.komponist') }}/nodered"
       tags: [never, offline]
 
     # NOTE: Uploading via uri Module with multipart/form-data body and HTTP POST

--- a/bootstrap_nodered.yml
+++ b/bootstrap_nodered.yml
@@ -73,7 +73,7 @@
 
     - name: (Online) Read `nodes.json` File for Bootstrapping Node-RED
       ansible.builtin.set_fact:
-        external_nodes: "{{ lookup('ansible.builtin.file', '{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered/nodes.json') }}"
+        external_nodes: '{{ lookup("ansible.builtin.file", komponist.deploy_dir | default(ansible_user_dir + "/.komponist") + "/nodered/nodes.json") }}'
       tags: [online]
 
     - name: (Online) Bootstrap Node-RED with External Nodes using nodes.json

--- a/export_flow_nodered.yml
+++ b/export_flow_nodered.yml
@@ -82,7 +82,7 @@
 
     - name: Create flows.json into deploy/nodered directory
       ansible.builtin.copy:
-        dest: "{{ komponist.deploy_dir }}/nodered/flows_{{ ansible_date_time.date }}.json"
+        dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered/flows_{{ ansible_date_time.date }}.json"
         content: "{{ final_flow | to_nice_json }}"
         mode: '0644'
 

--- a/export_nodes_nodered.yml
+++ b/export_nodes_nodered.yml
@@ -80,7 +80,7 @@
     - name: Generate nodes.json File for External Node Modules
       ansible.builtin.copy:
         dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered/nodes.json"
-        content: "{{ external_nodes | to_nice_jsotrue
+        content: "{{ external_nodes | to_nice_json }}"
         mode: "0640"
       tags: [always]
 

--- a/export_nodes_nodered.yml
+++ b/export_nodes_nodered.yml
@@ -22,7 +22,7 @@
 ---
 - name: Export Node-RED Nodes from Node-RED for Offline Installation
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   vars_files:
     - vars/config.yml
     - vars/creds.yml
@@ -79,15 +79,15 @@
 
     - name: Generate nodes.json File for External Node Modules
       ansible.builtin.copy:
-        dest: "{{ komponist.deploy_dir }}/nodered/nodes.json"
-        content: "{{ external_nodes | to_nice_json }}"
+        dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered/nodes.json"
+        content: "{{ external_nodes | to_nice_jsotrue
         mode: "0640"
       tags: [always]
 
     - name: External Nodes in Node-RED instance
       ansible.builtin.get_url:
         url: "https://registry.npmjs.org/{{ item.module }}/-/{{ item.module }}-{{ item.version }}.tgz"
-        dest: "{{ komponist.deploy_dir }}/nodered/"
+        dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered/"
         mode: "0640"
       loop: "{{ external_nodes }}"
       tags: [never, offline]

--- a/generate_stack.yml
+++ b/generate_stack.yml
@@ -21,6 +21,7 @@
 ---
 - name: Komponist Stack Generation Playbook
   hosts: localhost
+  gather_facts: true
   vars_files:
     - vars/config.yml
     - vars/creds.yml
@@ -28,7 +29,7 @@
 
     - name: "(KOMPONIST) Generating Directory for Production-Ready Files"
       ansible.builtin.file:
-        name: "{{ komponist.deploy_dir }}"
+        name: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}"
         state: directory
         mode: "0755"
 
@@ -43,7 +44,7 @@
           ansible.builtin.command:
             cmd: docker compose {{ compose_files }} config --no-interpolate --no-path-resolution --quiet
           args:
-            chdir: "{{ komponist.deploy_dir }}"
+            chdir: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}"
           vars:
             compose_files: >-
               {{ komponist.configuration.keys() | map('regex_replace', '^(.*)$', ' -f docker-compose.\1.yml') | join | trim }}
@@ -58,7 +59,7 @@
                 --no-path-resolution
                 -o docker-compose.yml
           args:
-            chdir: "{{ komponist.deploy_dir }}"
+            chdir: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}"
           vars:
             compose_files: >-
               {{ komponist.configuration.keys() | map('regex_replace', '^(.*)$', ' -f docker-compose.\1.yml') | join | trim }}
@@ -67,12 +68,12 @@
         - name: "(KOMPONIST) Update the header for generated docker-compose.yml file"
           ansible.builtin.blockinfile:
             block: "{{ lookup('ansible.builtin.template', 'templates/license_header.txt.j2') }}"
-            path: "{{ komponist.deploy_dir }}/docker-compose.yml"
+            path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.yml"
             insertbefore: "BOF"
             marker: ""
 
         - name: "(KOMPONIST) Generating the .env file for the Project"
           ansible.builtin.template:
             src: config/komponist.env.j2
-            dest: "{{ komponist.deploy_dir }}/.env"
-            mode: "0755"
+            dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/.env"
+            mode: "0644"

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,6 +2,6 @@
 ---
 collections:
   - name: community.docker
-    version: 3.4.8
+    version: 4.1.0
   - name: ansible.utils
-    version: 2.10.3
+    version: 5.1.2

--- a/tasks/configure-grafana.yml
+++ b/tasks/configure-grafana.yml
@@ -19,18 +19,18 @@
 ---
 - name: '(Grafana) Creating Deployment Specific Directory'
   ansible.builtin.file:
-    name: "{{ komponist.deploy_dir }}/grafana/provisioning/datasources"
+    name: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/grafana/provisioning/datasources"
     state: directory
     mode: "0755"
 
 - name: '(Grafana) Generating Datasources File'
   ansible.builtin.template:
     src: config/grafana/provisioning/datasources/datasources.yml.j2
-    dest: "{{ komponist.deploy_dir }}/grafana/provisioning/datasources/datasources.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/grafana/provisioning/datasources/datasources.yml"
+    mode: "0644"
 
 - name: '(Grafana) Generating Compose Service File for Deployment'
   ansible.builtin.template:
     src: services/docker-compose.grafana.yml.j2
-    dest: "{{ komponist.deploy_dir }}/docker-compose.grafana.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.grafana.yml"
+    mode: "0644"

--- a/tasks/configure-influxdbv1.yml
+++ b/tasks/configure-influxdbv1.yml
@@ -20,5 +20,5 @@
 - name: '(InfluxDBv1) Generating Compose Service File for Deployment'
   ansible.builtin.template:
     src: services/docker-compose.influxdbv1.yml.j2
-    dest: "{{ komponist.deploy_dir }}/docker-compose.influxdbv1.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.influxdbv1.yml"
+    mode: "0644"

--- a/tasks/configure-influxdbv2.yml
+++ b/tasks/configure-influxdbv2.yml
@@ -20,5 +20,5 @@
 - name: '(InfluxDBv2) Generating Compose Service File for Deployment'
   ansible.builtin.template:
     src: services/docker-compose.influxdbv2.yml.j2
-    dest: "{{ komponist.deploy_dir }}/docker-compose.influxdbv2.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.influxdbv2.yml"
+    mode: "0644"

--- a/tasks/configure-mosquitto.yml
+++ b/tasks/configure-mosquitto.yml
@@ -19,32 +19,32 @@
 ---
 - name: '(Mosquitto) Creating Deployment Specific Directory'
   ansible.builtin.file:
-    name: "{{ komponist.deploy_dir }}/mosquitto"
+    name: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/mosquitto"
     state: directory
     mode: "0755"
 
 - name: '(Mosquitto) Generating Configuration File for Deployment'
   ansible.builtin.template:
     src: "config/mosquitto/mosquitto.conf.j2"
-    dest: "{{ komponist.deploy_dir }}/mosquitto/mosquitto.conf"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/mosquitto/mosquitto.conf"
+    mode: "0644"
 
 - name: '(Mosquitto) Generating Authentication Users File for Deployment'
   block:
     - name: Generating Users file (as plain-text)
       ansible.builtin.template:
         src: "config/mosquitto/users.j2"
-        dest: "{{ komponist.deploy_dir }}/mosquitto/users"
-        mode: "0755"
+        dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/mosquitto/users"
+        mode: "0644"
 
 - name: '(Mosquitto) Generating Access Control List File for Deployment'
   ansible.builtin.template:
     src: "config/mosquitto/acl.j2"
-    dest: "{{ komponist.deploy_dir }}/mosquitto/acl"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/mosquitto/acl"
+    mode: "0644"
 
 - name: '(Mosquitto) Generating Compose Service File for Deployment'
   ansible.builtin.template:
     src: services/docker-compose.mosquitto.yml.j2
-    dest: "{{ komponist.deploy_dir }}/docker-compose.mosquitto.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.mosquitto.yml"
+    mode: "0644"

--- a/tasks/configure-nodered.yml
+++ b/tasks/configure-nodered.yml
@@ -19,18 +19,18 @@
 ---
 - name: '(Node-RED) Creating Deployment Specific Directory'
   ansible.builtin.file:
-    name: "{{ komponist.deploy_dir }}/nodered"
+    name: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered"
     state: directory
     mode: "0755"
 
 - name: '(Node-RED) Generating settings.js File for Deployment'
   ansible.builtin.template:
     src: config/nodered/settings.js.j2
-    dest: "{{ komponist.deploy_dir }}/nodered/settings.js"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered/settings.js"
+    mode: "0644"
 
 - name: '(Node-RED) Generating Compose Service File for Deployment'
   ansible.builtin.template:
     src: services/docker-compose.nodered.yml.j2
-    dest: "{{ komponist.deploy_dir }}/docker-compose.nodered.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.nodered.yml"
+    mode: "0644"

--- a/tasks/configure-questdb.yml
+++ b/tasks/configure-questdb.yml
@@ -20,5 +20,5 @@
 - name: '(QuestDB) Generating Compose Service File for Deployment'
   ansible.builtin.template:
     src: services/docker-compose.questdb.yml.j2
-    dest: "{{ komponist.deploy_dir }}/docker-compose.questdb.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.questdb.yml"
+    mode: "0644"

--- a/tasks/configure-telegraf.yml
+++ b/tasks/configure-telegraf.yml
@@ -1,18 +1,18 @@
 ---
 - name: '(Telegraf) Creating Deployment Directory'
   ansible.builtin.file:
-    name: "{{ komponist.deploy_dir }}/telegraf"
+    name: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/telegraf"
     state: directory
     mode: "0755"
 
 - name: '(Telegraf) Generating Configuration File'
   ansible.builtin.template:
     src: "config/telegraf/telegraf.conf.j2"
-    dest: "{{ komponist.deploy_dir }}/telegraf/telegraf.conf"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/telegraf/telegraf.conf"
+    mode: "0644"
 
 - name: '(Telegraf) Generating Compose Service File for Deployment'
   ansible.builtin.template:
     src: services/docker-compose.telegraf.yml.j2
-    dest: "{{ komponist.deploy_dir }}/docker-compose.telegraf.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.telegraf.yml"
+    mode: "0644"

--- a/tasks/configure-timescaledb.yml
+++ b/tasks/configure-timescaledb.yml
@@ -20,5 +20,5 @@
 - name: '(TimescaleDB) Generating Compose Service File for Deployment'
   ansible.builtin.template:
     src: services/docker-compose.timescaledb.yml.j2
-    dest: "{{ komponist.deploy_dir }}/docker-compose.timescaledb.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.timescaledb.yml"
+    mode: "0644"

--- a/tasks/configure-traefik.yml
+++ b/tasks/configure-traefik.yml
@@ -19,7 +19,7 @@
 ---
 - name: '(Traefik) Creating Deployment Specific Directory'
   ansible.builtin.file:
-    name: "{{ komponist.deploy_dir }}/traefik/configurations"
+    name: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik/configurations"
     state: directory
     mode: "0755"
 
@@ -27,19 +27,19 @@
 - name: '(Traefik) Generating Traefik Configuration File'
   ansible.builtin.template:
     src: config/traefik/traefik.yml.j2
-    dest: "{{ komponist.deploy_dir }}/traefik/traefik.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik/traefik.yml"
+    mode: "0644"
 
 
 - name: '(Traefik) Generating Dynamic Configuration Files for Traefik'
   ansible.builtin.template:
     src: templates/config/traefik/configurations/dynamic.yml.j2
-    dest: "{{ komponist.deploy_dir }}/traefik/configurations/dynamic.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik/configurations/dynamic.yml"
+    mode: "0644"
 
 
 - name: '(Traefik) Generating Compose Service File for Deployment'
   ansible.builtin.template:
     src: services/docker-compose.traefik.yml.j2
-    dest: "{{ komponist.deploy_dir }}/docker-compose.traefik.yml"
-    mode: "0755"
+    dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.traefik.yml"
+    mode: "0644"

--- a/tests/services/test_config_grafana.yml
+++ b/tests/services/test_config_grafana.yml
@@ -2,11 +2,11 @@
 ---
 - name: Get stats for Grafana Files in dedicated directory under deploy_dir
   ansible.builtin.stat:
-    path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/grafana/provisioning/datasources/datasources.yml"
+    path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/grafana/provisioning/datasources/datasources.yml"
   register: test_grafana_datasources_stat
 
 - name: Test if the Grafana Datasources File in dedicated directory exists under deploy_dir
   ansible.builtin.assert:
-    that: test_grafana_datasources_stat.stat.exists and test_grafana_datasources_stat.stat.mode == '0755'
-    fail_msg: "FAIL: Datasources File DOES NOT exist in {{ komponist.deploy_dir }}/grafana/provisioning/datasources directory."
-    success_msg: "PASS: Datasources File exists in {{ komponist.deploy_dir }}/grafana/provisioning/datasources directory."
+    that: test_grafana_datasources_stat.stat.exists and test_grafana_datasources_stat.stat.mode == '0644'
+    fail_msg: "FAIL: Datasources File DOES NOT exist in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/grafana/provisioning/datasources directory."
+    success_msg: "PASS: Datasources File exists in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/grafana/provisioning/datasources directory."

--- a/tests/services/test_config_influxdb.yml
+++ b/tests/services/test_config_influxdb.yml
@@ -2,11 +2,11 @@
 ---
 - name: Get stats for InfluxDBv1/v2 environment file in dedicated directory under deploy_dir
   ansible.builtin.stat:
-    path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/{{ item }}/{{ item }}.env"
+    path: "{{ playbook_dir }}/../{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/{{ item }}/{{ item }}.env"
   register: test_service_envfile_stat
 
 - name: Test if the InfluxDBv1/v2 environment file in dedicated directory exists under deploy_dir
   ansible.builtin.assert:
     that: test_service_envfile_stat.stat.exists and test_service_envfile_stat.stat.mode == '0755'
-    fail_msg: "FAIL: {{ item }}.env DOES NOT exist in {{ komponist.deploy_dir }}/{{ item }} directory."
-    success_msg: "PASS: {{ item }}.env File exists in {{ komponist.deploy_dir }}/{{ item }} directory."
+    fail_msg: "FAIL: {{ item }}.env DOES NOT exist in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/{{ item }} directory."
+    success_msg: "PASS: {{ item }}.env File exists in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/{{ item }} directory."

--- a/tests/services/test_config_mosquitto.yml
+++ b/tests/services/test_config_mosquitto.yml
@@ -2,7 +2,7 @@
 ---
 - name: Get stats for Mosquitto related configuration files
   ansible.builtin.stat:
-    path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/mosquitto/{{ item }}"
+    path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/mosquitto/{{ item }}"
   register: test_mosquitto_files_stat
   loop:
     - acl
@@ -11,9 +11,9 @@
 
 - name: Test if Mosquitto related configuration files exist in deploy_dir
   ansible.builtin.assert:
-    that: item.stat.exists and item.stat.mode == '0755'
-    fail_msg: "FAIL: {{ item.item }} DOES NOT exist in {{ komponist.deploy_dir }}/mosquitto directory"
-    success_msg: "PASS: {{ item.item }}  exists in {{ komponist.deploy_dir }}/mosquitto directory"
+    that: item.stat.exists and item.stat.mode == '0644'
+    fail_msg: "FAIL: {{ item.item }} DOES NOT exist in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/mosquitto directory"
+    success_msg: "PASS: {{ item.item }}  exists in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/mosquitto directory"
   loop: "{{ test_mosquitto_files_stat.results | map('ansible.utils.keep_keys', ['item', 'exists', 'mode']) }}"
   loop_control:
     label: "{{ item.item }}"

--- a/tests/services/test_config_nodered.yml
+++ b/tests/services/test_config_nodered.yml
@@ -2,11 +2,11 @@
 ---
 - name: Get stats for Node-RED settings file
   ansible.builtin.stat:
-    path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/nodered/settings.js"
+    path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered/settings.js"
   register: test_nodered_settings_file_stat
 
 - name: Test if settings.js Exists under deploy_dir directory
   ansible.builtin.assert:
-    that: test_nodered_settings_file_stat.stat.exists and test_nodered_settings_file_stat.stat.mode == '0755'
-    fail_msg: "FAIL: settings.js DOES NOT exist under {{ komponist.deploy_dir }}/nodered directory"
-    success_msg: "PASS: settings.js exists under {{ komponist.deploy_dir }}/nodered directory"
+    that: test_nodered_settings_file_stat.stat.exists and test_nodered_settings_file_stat.stat.mode == '0644'
+    fail_msg: "FAIL: settings.js DOES NOT exist under {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered directory"
+    success_msg: "PASS: settings.js exists under {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/nodered directory"

--- a/tests/services/test_config_telegraf.yml
+++ b/tests/services/test_config_telegraf.yml
@@ -2,11 +2,11 @@
 ---
 - name: Get stats for Telegraf configuration file
   ansible.builtin.stat:
-    path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/telegraf/telegraf.conf"
+    path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/telegraf/telegraf.conf"
   register: test_telegraf_file_stat
 
 - name: Test if Telegraf configuration file in deploy_dir
   ansible.builtin.assert:
-    that: test_telegraf_file_stat.stat.exists and test_telegraf_file_stat.stat.mode == '0755'
-    fail_msg: "FAIL: telegraf.conf DOES NOT exist under {{ komponist.deploy_dir }}/telegraf directory"
-    success_msg: "PASS: telegraf.conf exists under {{ komponist.deploy_dir }}/telegraf directory"
+    that: test_telegraf_file_stat.stat.exists and test_telegraf_file_stat.stat.mode == '0644'
+    fail_msg: "FAIL: telegraf.conf DOES NOT exist under {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/telegraf directory"
+    success_msg: "PASS: telegraf.conf exists under {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/telegraf directory"

--- a/tests/services/test_config_traefik.yml
+++ b/tests/services/test_config_traefik.yml
@@ -2,7 +2,7 @@
 ---
 - name: Get stats for Traefik related configuration files
   ansible.builtin.stat:
-    path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/traefik/{{ item }}"
+    path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik/{{ item }}"
   register: test_traefik_files_stat
   loop:
     - traefik.yml
@@ -10,7 +10,7 @@
 
 - name: Test if Traefik related configuration files in deploy_dir
   ansible.builtin.assert:
-    that: item.stat.exists and item.stat.mode == '0755'
-    fail_msg: "FAIL: {{ item.item }} DOES NOT exist under {{ komponist.deploy_dir }}/traefik directory"
-    success_msg: "PASS: {{ item.item }} exists under {{ komponist.deploy_dir }}/traefik directory"
+    that: item.stat.exists and item.stat.mode == '0644'
+    fail_msg: "FAIL: {{ item.item }} DOES NOT exist under {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik directory"
+    success_msg: "PASS: {{ item.item }} exists under {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik directory"
   loop: "{{ test_traefik_files_stat.results | map('ansible.utils.keep_keys', ['item', 'exists', 'mode']) }}"

--- a/tests/test_compose_containers.yml
+++ b/tests/test_compose_containers.yml
@@ -2,7 +2,7 @@
 ---
 - name: Bring the Compose Application up and check if containers exist and are running
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   vars_files:
     - "{{ playbook_dir }}/../vars/config.yml"
 
@@ -11,7 +11,7 @@
       block:
         - name: (Komponist-Docker) Bring the Compose Application up
           ansible.builtin.command:
-            cmd: docker compose --project-directory="{{ playbook_dir }}/../deploy" up --quiet-pull -d
+            cmd: docker compose --project-directory="{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}" up --quiet-pull -d
           register: compose_up
           changed_when: compose_up.rc != 0
 
@@ -42,6 +42,6 @@
       always:
         - name: (Komponist-Docker) docker compose down --volumes
           ansible.builtin.command:
-            cmd: docker compose --project-directory="{{ playbook_dir }}/../deploy" down --volumes
+            cmd: docker compose --project-directory="{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}" down --volumes
           register: compose_down
           changed_when: compose_down.rc != 0

--- a/tests/test_file_contents.yml
+++ b/tests/test_file_contents.yml
@@ -2,13 +2,13 @@
 ---
 - name: Test Content for Mosquitto / Node-RED Generated Files
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   vars_files:
     - "{{ playbook_dir }}/../vars/config.yml"
   tasks:
     - name: (Mosquitto) Perform Lookup for Mosquitto Users File
       ansible.builtin.set_fact:
-        mosquitto_users_file: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/../{{ komponist.deploy_dir }}/mosquitto/users') }}"
+        mosquitto_users_file: '{{ lookup("ansible.builtin.file", komponist.deploy_dir | default(ansible_user_dir + "/.komponist") + "/mosquitto/users") }}'
 
     - name: (Mosquitto) Assert that plain-text passwords were encrypted by Custom Filter mosquitto_passwd
       ansible.builtin.assert:
@@ -20,7 +20,7 @@
 
     - name: (Node-RED) Perform Lookup for Node-RED settings.js file
       ansible.builtin.set_fact:
-        nodered_settings_file: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/../{{ komponist.deploy_dir }}/nodered/settings.js') }}"
+        nodered_settings_file: '{{ lookup("ansible.builtin.file", komponist.deploy_dir | default(ansible_user_dir + "/.komponist") + "/nodered/settings.js") }}'
 
     - name: (Node-RED) Assert that Generated passwords for Node-RED are encrypted
       ansible.builtin.assert:

--- a/tests/test_generated_directories.yml
+++ b/tests/test_generated_directories.yml
@@ -11,17 +11,17 @@
   vars_files:
     - "{{ playbook_dir }}/../vars/config.yml"
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
 
   pre_tasks:
     - name: Collect Stat Information for deploy_dir
       ansible.builtin.stat:
-        path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}"
+        path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}"
       register: test_deploy_dir_state
 
     - name: Collect Stat Information for Services under deploy_dir
       ansible.builtin.stat:
-        path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/{{ item }}"
+        path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/{{ item }}"
       register: test_deploy_dir_service_state
       loop: "{{ komponist.configuration.keys() }}"
 
@@ -30,14 +30,14 @@
       ansible.builtin.assert:
         that:
           - test_deploy_dir_state.stat.exists and test_deploy_dir_state.stat.isdir
-        fail_msg: "Cannot Find the {{ komponist.deploy_dir }} in the root of the repository."
-        success_msg: "{{ komponist.deploy_dir }} exists in the root of the repository."
+        fail_msg: "Cannot Find the {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} in the root of the repository."
+        success_msg: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} exists in the root of the repository."
 
     - name: Test if the subdirectories for each Service exists under deploy_dir
       ansible.builtin.assert:
         that: item.stat.exists and item.stat.isdir and item.stat.mode == '0755'
-        fail_msg: "FAIL: {{ item.item }} does not exist under {{ komponist.deploy_dir }} directory"
-        success_msg: "PASS: {{ item.item }} exist under {{ komponist.deploy_dir }} directory"
+        fail_msg: "FAIL: {{ item.item }} does not exist under {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory"
+        success_msg: "PASS: {{ item.item }} exist under {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory"
         quiet: false
       loop: "{{ test_deploy_dir_service_state.results | map('ansible.utils.keep_keys', ['item', 'exists', 'isdir', 'mode']) }}"
       when: "item.item not in excluded_services"

--- a/tests/test_generated_files.yml
+++ b/tests/test_generated_files.yml
@@ -4,34 +4,34 @@
   vars_files:
     - "{{ playbook_dir }}/../vars/config.yml"
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Check for .env File in deploy_dir
       block:
         - name: Get stats for .env in deploy_dir
           ansible.builtin.stat:
-            path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/.env"
+            path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/.env"
           register: test_compose_env_file_stat
 
         - name: Check if .env file is generated
           ansible.builtin.assert:
-            that: test_compose_env_file_stat.stat.exists and test_compose_env_file_stat.stat.mode == "0755"
-            fail_msg: "FAIL: .env File DOES NOT exist in {{ komponist.deploy_dir }} directory."
-            success_msg: "PASS: .env File exists in {{ komponist.deploy_dir }} directory."
+            that: test_compose_env_file_stat.stat.exists and test_compose_env_file_stat.stat.mode == "0644"
+            fail_msg: "FAIL: .env File DOES NOT exist in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
+            success_msg: "PASS: .env File exists in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
 
     - name: Check for Generated Docker Compose Services Files
       block:
         - name: Get stats for configured Docker Compose services
           ansible.builtin.stat:
-            path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/docker-compose.{{ item }}.yml"
+            path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.{{ item }}.yml"
           loop: "{{ komponist.configuration.keys() }}"
           register: test_compose_services_files_stat
 
         - name: Check if respective Docker Compose Service Files exist
           ansible.builtin.assert:
             that: item.stat.exists and item.stat.mode
-            fail_msg: "FAIL: docker-compose.{{ item.item }}.yml DOES NOT exist in {{ komponist.deploy_dir }} directory."
-            success_msg: "PASS: docker-compose.{{ item.item }}.yml File exists in {{ komponist.deploy_dir }} directory."
+            fail_msg: "FAIL: docker-compose.{{ item.item }}.yml DOES NOT exist in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
+            success_msg: "PASS: docker-compose.{{ item.item }}.yml File exists in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
           loop: "{{ test_compose_services_files_stat.results | map('ansible.utils.keep_keys', ['item', 'exists', 'mode']) }}"
           loop_control:
             label: "{{ item.item }}"
@@ -40,14 +40,14 @@
       block:
         - name: Get stats for Deployment-Ready docker-compose.yml file
           ansible.builtin.stat:
-            path: "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/docker-compose.yml"
+            path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.yml"
           register: test_compose_deployment_file_stat
 
         - name: Check if docker-compose.yml File exist
           ansible.builtin.assert:
             that: test_compose_deployment_file_stat.stat.exists and test_compose_deployment_file_stat.stat.mode == '0644'
-            fail_msg: "FAIL: docker-compose.yml DOES NOT exist in {{ komponist.deploy_dir }} directory."
-            success_msg: "PASS: docker-compose.yml File exists in {{ komponist.deploy_dir }} directory."
+            fail_msg: "FAIL: docker-compose.yml DOES NOT exist in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
+            success_msg: "PASS: docker-compose.yml File exists in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
 
     - name: Check Mosquitto MQTT Generated Files in deploy_dir
       ansible.builtin.include_tasks: "{{ playbook_dir }}/services/test_config_mosquitto.yml"

--- a/tests/test_schemas.yml
+++ b/tests/test_schemas.yml
@@ -4,18 +4,18 @@
   hosts: localhost
   vars_files:
     - "{{ playbook_dir }}/../vars/config.yml"
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: JSON Schema Validation Checks for Compose Services and compose files
       ansible.builtin.include_tasks: "{{ playbook_dir }}/services/test_compose_schema.yml"
       with_fileglob:
-        - "{{ playbook_dir }}/../{{ komponist.deploy_dir }}/*.yml"
+        - "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/*.yml"
 
     - name: JSON Schema Validation Checks for Traefik related files
       block:
         - name: Perform Lookup for Traefik Static Configuration File
           ansible.builtin.set_fact:
-            traefik_static_conf: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/../{{ komponist.deploy_dir }}/traefik/traefik.yml') | from_yaml }}"
+            traefik_static_conf: '{{ lookup("ansible.builtin.file", komponist.deploy_dir | default(ansible_user_dir + "/.komponist") + "/traefik/traefik.yml") | from_yaml }}'
             traefik_static_schema: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/schemas/traefik-v2.json') }}"
 
         - name: Perform Validation for Traefik Static Configuration JSONSchema
@@ -25,12 +25,12 @@
         - name: Assert that Validation for Traefik Static File is successful for JSONSchema
           ansible.builtin.assert:
             that: "{{ traefik_static_schema_checks | length == 0 }}"
-            fail_msg: "FAIL: Schema for {{ komponist.deploy_dir }}/traefik/traefik.yml does not match the traefik-v2.json"
-            success_msg: "PASS: Schema for {{ komponist.deploy_dir }}/traefik/traefik.yml matches the traefik-v2.json"
+            fail_msg: "FAIL: Schema for {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik/traefik.yml does not match the traefik-v2.json"
+            success_msg: "PASS: Schema for {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik/traefik.yml matches the traefik-v2.json"
 
         - name: Perform Lookup for Traefik Dynamic Configuration File
           ansible.builtin.set_fact:
-            traefik_dynamic_conf: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/../{{ komponist.deploy_dir }}/{{ dyn_file }}') | from_yaml }}"
+            traefik_dynamic_conf: '{{ lookup("ansible.builtin.file", komponist.deploy_dir | default(ansible_user_dir + "/.komponist") + "/" + dyn_file) | from_yaml }}'
             traefik_dynamic_schema: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/schemas/traefik-v2-file-provider.json') }}"
           vars:
             dyn_file: traefik/configurations/dynamic.yml
@@ -42,5 +42,5 @@
         - name: Assert that Validation for Traefik Dynamic File is successful for JSONSchema
           ansible.builtin.assert:
             that: "{{ traefik_dynamic_schema_checks | length == 0 }}"
-            fail_msg: "FAIL: Schema for {{ komponist.deploy_dir }}/traefik/configurations/dynamic.yml does not match the traefik-v2-file-provider.json"
-            success_msg: "PASS: Schema for {{ komponist.deploy_dir }}/traefik/configurations/dynamic.yml matches the traefik-v2-file-provider.json"
+            fail_msg: "FAIL: Schema for {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik/configurations/dynamic.yml does not match the traefik-v2-file-provider.json"
+            success_msg: "PASS: Schema for {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/traefik/configurations/dynamic.yml matches the traefik-v2-file-provider.json"

--- a/vars/config.yml
+++ b/vars/config.yml
@@ -26,11 +26,12 @@ komponist:
   # Default Value: komponist
   project_name: 'komponist'
 
-  # Parameter: `deploy_dir` (REQUIRED)
+  # Parameter: `deploy_dir` (OPTIONAL)
   # Function: Creates a directory in the dedicated path with the generated
   #           settings files + docker compose files
   # Acceptable Value: Complete Path to where the directory should exist
-  deploy_dir: './deploy'
+  # Default Value: ~/.komponist
+  # deploy_dir: './deploy'
 
   # Parameter: `data_persistence` (OPTIONAL)
   # Function: Let Komponist know if the generated data from containers needs to stored


### PR DESCRIPTION
this large refactoring change resolves #28.

The default `deploy_dir` value will be `~/.komponist` if not explicitly specified.

The file-mode is also controlled to reflect mode `0644` as opposed to `0755`. Directories will still have `0755`