### PR TITLE
refactor: use `include` spec for docker compose

### DIFF
--- a/generate_stack.yml
+++ b/generate_stack.yml
@@ -2,7 +2,7 @@
 #
 # Komponist - Generate Your Favourite Compose Stack With the Least Effort
 #
-# Copyright (C) 2023  Shantanoo "Shan" Desai <sdes.softdev@gmail.com>
+# Copyright (C) 2025  Shantanoo "Shan" Desai <sdes.softdev@gmail.com>
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Affero General Public License as published
@@ -38,42 +38,29 @@
       with_items:
         - "{{ komponist.configuration.keys() }}"
 
-    - name: "(KOMPONIST) Validation and Generation of docker-compose.yml"
-      block:
-        - name: "(DockerCompose) Validating Docker Compose Services"
-          ansible.builtin.command:
-            cmd: docker compose {{ compose_files }} config --no-interpolate --no-path-resolution --quiet
-          args:
-            chdir: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}"
-          vars:
-            compose_files: >-
-              {{ komponist.configuration.keys() | map('regex_replace', '^(.*)$', ' -f docker-compose.\1.yml') | join | trim }}
-          register: docker_compose_validity
-          changed_when: docker_compose_validity.rc != 0
+    - name: "(KOMPONIST) Generating Entrypoint compose.yml file from Templates"
+      ansible.builtin.template:
+        src: templates/services/compose.yml.j2
+        dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/compose.yml"
+        mode: "0644"
 
-        - name: "(DockerCompose) Generating docker-compose.yml file if all services are valid"
-          ansible.builtin.command:
-            cmd: >
-              docker compose -p {{ komponist.configuration.project_name | default('komponist') }} {{ compose_files }} config
-                --no-interpolate
-                --no-path-resolution
-                -o docker-compose.yml
-          args:
-            chdir: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}"
-          vars:
-            compose_files: >-
-              {{ komponist.configuration.keys() | map('regex_replace', '^(.*)$', ' -f docker-compose.\1.yml') | join | trim }}
-          changed_when: docker_compose_validity.rc != 0
+    - name: "(KOMPONIST) Validating Docker Compose Services"
+      ansible.builtin.command:
+        cmd: docker compose config --no-interpolate --no-path-resolution --quiet
+      args:
+        chdir: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}"
+      register: docker_compose_validity
+      changed_when: docker_compose_validity.rc != 0
 
-        - name: "(KOMPONIST) Update the header for generated docker-compose.yml file"
-          ansible.builtin.blockinfile:
-            block: "{{ lookup('ansible.builtin.template', 'templates/license_header.txt.j2') }}"
-            path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.yml"
-            insertbefore: "BOF"
-            marker: ""
+    - name: "(KOMPONIST) Update the header for generated docker-compose.yml file"
+      ansible.builtin.blockinfile:
+        block: "{{ lookup('ansible.builtin.template', 'templates/license_header.txt.j2') }}"
+        path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/compose.yml"
+        insertbefore: "BOF"
+        marker: ""
 
-        - name: "(KOMPONIST) Generating the .env file for the Project"
-          ansible.builtin.template:
-            src: config/komponist.env.j2
-            dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/.env"
-            mode: "0644"
+    - name: "(KOMPONIST) Generating the .env file for the Project"
+      ansible.builtin.template:
+        src: config/komponist.env.j2
+        dest: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/.env"
+        mode: "0644"

--- a/templates/services/compose.yml.j2
+++ b/templates/services/compose.yml.j2
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Komponist - Generate Your Favourite Compose Stack With the Least Effort
+#
+# Copyright (C) 2025  Shantanoo "Shan" Desai <sdes.softdev@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+{{ ansible_managed | comment }}
+
+{# compose.yml.j2: Jinja2 Template for Main Compose Entrypoint File #}
+
+name: {{ komponist.project_name | default('komponist') }}
+
+include:
+{%for service in komponist.configuration.keys() %}
+  - {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.{{ service }}.yml
+{% endfor %}

--- a/tests/schemas/compose-spec.json
+++ b/tests/schemas/compose-spec.json
@@ -1,820 +1,1024 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-09/schema#",
-    "id": "compose_spec.json",
-    "type": "object",
-    "title": "Compose Specification",
-    "description": "The Compose file is a YAML file defining a multi-containers based application.",
-  
-    "properties": {
-      "version": {
-        "type": "string",
-        "description": "declared for backward compatibility, ignored."
+  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "id": "compose_spec.json",
+  "type": "object",
+  "title": "Compose Specification",
+  "description": "The Compose file is a YAML file defining a multi-containers based application.",
+
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "declared for backward compatibility, ignored."
+    },
+
+    "name": {
+      "type": "string",
+      "description": "define the Compose project name, until user defines one explicitly."
+    },
+
+    "include": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/include"
       },
-  
-      "name": {
-        "type": "string",
-        "pattern": "^[a-z0-9][a-z0-9_-]*$",
-        "description": "define the Compose project name, until user defines one explicitly."
-      },
-  
-      "services": {
-        "id": "#/properties/services",
-        "type": "object",
-        "patternProperties": {
-          "^[a-zA-Z0-9._-]+$": {
-            "$ref": "#/definitions/service"
-          }
-        },
-        "additionalProperties": false
-      },
-  
-      "networks": {
-        "id": "#/properties/networks",
-        "type": "object",
-        "patternProperties": {
-          "^[a-zA-Z0-9._-]+$": {
-            "$ref": "#/definitions/network"
-          }
+      "description": "compose sub-projects to be included."
+    },
+
+    "services": {
+      "id": "#/properties/services",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/service"
         }
       },
-  
-      "volumes": {
-        "id": "#/properties/volumes",
-        "type": "object",
-        "patternProperties": {
-          "^[a-zA-Z0-9._-]+$": {
-            "$ref": "#/definitions/volume"
-          }
-        },
-        "additionalProperties": false
-      },
-  
-      "secrets": {
-        "id": "#/properties/secrets",
-        "type": "object",
-        "patternProperties": {
-          "^[a-zA-Z0-9._-]+$": {
-            "$ref": "#/definitions/secret"
-          }
-        },
-        "additionalProperties": false
-      },
-  
-      "configs": {
-        "id": "#/properties/configs",
-        "type": "object",
-        "patternProperties": {
-          "^[a-zA-Z0-9._-]+$": {
-            "$ref": "#/definitions/config"
-          }
-        },
-        "additionalProperties": false
+      "additionalProperties": false
+    },
+
+    "networks": {
+      "id": "#/properties/networks",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/network"
+        }
       }
     },
-  
-    "patternProperties": {"^x-": {}},
-    "additionalProperties": false,
-  
-    "definitions": {
-  
-      "service": {
-        "id": "#/definitions/service",
-        "type": "object",
-  
-        "properties": {
-          "deploy": {"$ref": "#/definitions/deployment"},
-          "build": {
-            "oneOf": [
-              {"type": "string"},
-              {
-                "type": "object",
-                "properties": {
-                  "context": {"type": "string"},
-                  "dockerfile": {"type": "string"},
-                  "dockerfile_inline": {"type": "string"},
-                  "args": {"$ref": "#/definitions/list_or_dict"},
-                  "ssh": {"$ref": "#/definitions/list_or_dict"},
-                  "labels": {"$ref": "#/definitions/list_or_dict"},
-                  "cache_from": {"type": "array", "items": {"type": "string"}},
-                  "cache_to": {"type": "array", "items": {"type": "string"}},
-                  "no_cache": {"type": "boolean"},
-                  "additional_contexts": {"$ref": "#/definitions/list_or_dict"},
-                  "network": {"type": "string"},
-                  "pull": {"type": "boolean"},
-                  "target": {"type": "string"},
-                  "shm_size": {"type": ["integer", "string"]},
-                  "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
-                  "isolation": {"type": "string"},
-                  "privileged": {"type": "boolean"},
-                  "secrets": {"$ref": "#/definitions/service_config_or_secret"},
-                  "tags": {"type": "array", "items": {"type": "string"}},
-                  "platforms": {"type": "array", "items": {"type": "string"}}
-                },
-                "additionalProperties": false,
-                "patternProperties": {"^x-": {}}
-              }
-            ]
-          },
-          "blkio_config": {
-            "type": "object",
-            "properties": {
-              "device_read_bps": {
-                "type": "array",
-                "items": {"$ref": "#/definitions/blkio_limit"}
-              },
-              "device_read_iops": {
-                "type": "array",
-                "items": {"$ref": "#/definitions/blkio_limit"}
-              },
-              "device_write_bps": {
-                "type": "array",
-                "items": {"$ref": "#/definitions/blkio_limit"}
-              },
-              "device_write_iops": {
-                "type": "array",
-                "items": {"$ref": "#/definitions/blkio_limit"}
-              },
-              "weight": {"type": "integer"},
-              "weight_device": {
-                "type": "array",
-                "items": {"$ref": "#/definitions/blkio_weight"}
-              }
-            },
-            "additionalProperties": false
-          },
-          "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-          "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-          "cgroup": {"type": "string", "enum": ["host", "private"]},
-          "cgroup_parent": {"type": "string"},
-          "command": {"$ref": "#/definitions/command"},
-          "configs": {"$ref": "#/definitions/service_config_or_secret"},
-          "container_name": {"type": "string"},
-          "cpu_count": {"type": "integer", "minimum": 0},
-          "cpu_percent": {"type": "integer", "minimum": 0, "maximum": 100},
-          "cpu_shares": {"type": ["number", "string"]},
-          "cpu_quota": {"type": ["number", "string"]},
-          "cpu_period": {"type": ["number", "string"]},
-          "cpu_rt_period": {"type": ["number", "string"]},
-          "cpu_rt_runtime": {"type": ["number", "string"]},
-          "cpus": {"type": ["number", "string"]},
-          "cpuset": {"type": "string"},
-          "credential_spec": {
-            "type": "object",
-            "properties": {
-              "config": {"type": "string"},
-              "file": {"type": "string"},
-              "registry": {"type": "string"}
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          },
-          "depends_on": {
-            "oneOf": [
-              {"$ref": "#/definitions/list_of_strings"},
-              {
-                "type": "object",
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^[a-zA-Z0-9._-]+$": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                      "restart": {"type": "boolean"},
-                      "condition": {
-                        "type": "string",
-                        "enum": ["service_started", "service_healthy", "service_completed_successfully"]
-                      }
-                    },
-                    "required": ["condition"]
-                  }
-                }
-              }
-            ]
-          },
-          "device_cgroup_rules": {"$ref": "#/definitions/list_of_strings"},
-          "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-          "dns": {"$ref": "#/definitions/string_or_list"},
-          "dns_opt": {"type": "array","items": {"type": "string"}, "uniqueItems": true},
-          "dns_search": {"$ref": "#/definitions/string_or_list"},
-          "domainname": {"type": "string"},
-          "entrypoint": {"$ref": "#/definitions/command"},
-          "env_file": {"$ref": "#/definitions/string_or_list"},
-          "environment": {"$ref": "#/definitions/list_or_dict"},
-  
-          "expose": {
-            "type": "array",
-            "items": {
-              "type": ["string", "number"],
-              "format": "expose"
-            },
-            "uniqueItems": true
-          },
-          "extends": {
-            "oneOf": [
-              {"type": "string"},
-              {
-                "type": "object",
-  
-                "properties": {
-                  "service": {"type": "string"},
-                  "file": {"type": "string"}
-                },
-                "required": ["service"],
-                "additionalProperties": false
-              }
-            ]
-          },
-          "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-          "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
-          "group_add": {
-            "type": "array",
-            "items": {
-              "type": ["string", "number"]
-            },
-            "uniqueItems": true
-          },
-          "healthcheck": {"$ref": "#/definitions/healthcheck"},
-          "hostname": {"type": "string"},
-          "image": {"type": "string"},
-          "init": {"type": "boolean"},
-          "ipc": {"type": "string"},
-          "isolation": {"type": "string"},
-          "labels": {"$ref": "#/definitions/list_or_dict"},
-          "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-          "logging": {
-            "type": "object",
-  
-            "properties": {
-              "driver": {"type": "string"},
-              "options": {
-                "type": "object",
-                "patternProperties": {
-                  "^.+$": {"type": ["string", "number", "null"]}
-                }
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          },
-          "mac_address": {"type": "string"},
-          "mem_limit": {"type": ["number", "string"]},
-          "mem_reservation": {"type": ["string", "integer"]},
-          "mem_swappiness": {"type": "integer"},
-          "memswap_limit": {"type": ["number", "string"]},
-          "network_mode": {"type": "string"},
-          "networks": {
-            "oneOf": [
-              {"$ref": "#/definitions/list_of_strings"},
-              {
-                "type": "object",
-                "patternProperties": {
-                  "^[a-zA-Z0-9._-]+$": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "aliases": {"$ref": "#/definitions/list_of_strings"},
-                          "ipv4_address": {"type": "string"},
-                          "ipv6_address": {"type": "string"},
-                          "link_local_ips": {"$ref": "#/definitions/list_of_strings"},
-                          "priority": {"type": "number"}
-                        },
-                        "additionalProperties": false,
-                        "patternProperties": {"^x-": {}}
-                      },
-                      {"type": "null"}
-                    ]
-                  }
-                },
-                "additionalProperties": false
-              }
-            ]
-          },
-          "oom_kill_disable": {"type": "boolean"},
-          "oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
-          "pid": {"type": ["string", "null"]},
-          "pids_limit": {"type": ["number", "string"]},
-          "platform": {"type": "string"},
-          "ports": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {"type": "number", "format": "ports"},
-                {"type": "string", "format": "ports"},
-                {
-                  "type": "object",
-                  "properties": {
-                    "mode": {"type": "string"},
-                    "host_ip": {"type": "string"},
-                    "target": {"type": "integer"},
-                    "published": {"type": ["string", "integer"]},
-                    "protocol": {"type": "string"}
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {"^x-": {}}
-                }
-              ]
-            },
-            "uniqueItems": true
-          },
-          "privileged": {"type": "boolean"},
-          "profiles": {"$ref": "#/definitions/list_of_strings"},
-          "pull_policy": {"type": "string", "enum": [
-            "always", "never", "if_not_present", "build", "missing"
-          ]},
-          "read_only": {"type": "boolean"},
-          "restart": {"type": "string"},
-          "runtime": {
-            "type": "string"
-          },
-          "scale": {
-            "type": "integer"
-          },
-          "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-          "shm_size": {"type": ["number", "string"]},
-          "secrets": {"$ref": "#/definitions/service_config_or_secret"},
-          "sysctls": {"$ref": "#/definitions/list_or_dict"},
-          "stdin_open": {"type": "boolean"},
-          "stop_grace_period": {"type": "string", "format": "duration"},
-          "stop_signal": {"type": "string"},
-          "storage_opt": {"type": "object"},
-          "tmpfs": {"$ref": "#/definitions/string_or_list"},
-          "tty": {"type": "boolean"},
-          "ulimits": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z]+$": {
-                "oneOf": [
-                  {"type": "integer"},
-                  {
-                    "type": "object",
-                    "properties": {
-                      "hard": {"type": "integer"},
-                      "soft": {"type": "integer"}
-                    },
-                    "required": ["soft", "hard"],
-                    "additionalProperties": false,
-                    "patternProperties": {"^x-": {}}
-                  }
-                ]
-              }
-            }
-          },
-          "user": {"type": "string"},
-          "uts": {"type": "string"},
-          "userns_mode": {"type": "string"},
-          "volumes": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {"type": "string"},
-                {
-                  "type": "object",
-                  "required": ["type"],
-                  "properties": {
-                    "type": {"type": "string"},
-                    "source": {"type": "string"},
-                    "target": {"type": "string"},
-                    "read_only": {"type": "boolean"},
-                    "consistency": {"type": "string"},
-                    "bind": {
-                      "type": "object",
-                      "properties": {
-                        "propagation": {"type": "string"},
-                        "create_host_path": {"type": "boolean"},
-                        "selinux": {"type": "string", "enum": ["z", "Z"]}
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {"^x-": {}}
-                    },
-                    "volume": {
-                      "type": "object",
-                      "properties": {
-                        "nocopy": {"type": "boolean"}
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {"^x-": {}}
-                    },
-                    "tmpfs": {
-                      "type": "object",
-                      "properties": {
-                        "size": {
-                          "oneOf": [
-                            {"type": "integer", "minimum": 0},
-                            {"type": "string"}
-                          ]
-                        },
-                        "mode": {"type": "number"}
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {"^x-": {}}
-                    }
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {"^x-": {}}
-                }
-              ]
-            },
-            "uniqueItems": true
-          },
-          "volumes_from": {
-            "type": "array",
-            "items": {"type": "string"},
-            "uniqueItems": true
-          },
-          "working_dir": {"type": "string"}
-        },
-        "patternProperties": {"^x-": {}},
-        "additionalProperties": false
-      },
-  
-      "healthcheck": {
-        "id": "#/definitions/healthcheck",
-        "type": "object",
-        "properties": {
-          "disable": {"type": "boolean"},
-          "interval": {"type": "string", "format": "duration"},
-          "retries": {"type": "number"},
-          "test": {
-            "oneOf": [
-              {"type": "string"},
-              {"type": "array", "items": {"type": "string"}}
-            ]
-          },
-          "timeout": {"type": "string", "format": "duration"},
-          "start_period": {"type": "string", "format": "duration"}
-        },
-        "additionalProperties": false,
-        "patternProperties": {"^x-": {}}
-      },
-      "deployment": {
-        "id": "#/definitions/deployment",
-        "type": ["object", "null"],
-        "properties": {
-          "mode": {"type": "string"},
-          "endpoint_mode": {"type": "string"},
-          "replicas": {"type": "integer"},
-          "labels": {"$ref": "#/definitions/list_or_dict"},
-          "rollback_config": {
-            "type": "object",
-            "properties": {
-              "parallelism": {"type": "integer"},
-              "delay": {"type": "string", "format": "duration"},
-              "failure_action": {"type": "string"},
-              "monitor": {"type": "string", "format": "duration"},
-              "max_failure_ratio": {"type": "number"},
-              "order": {"type": "string", "enum": [
-                "start-first", "stop-first"
-              ]}
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          },
-          "update_config": {
-            "type": "object",
-            "properties": {
-              "parallelism": {"type": "integer"},
-              "delay": {"type": "string", "format": "duration"},
-              "failure_action": {"type": "string"},
-              "monitor": {"type": "string", "format": "duration"},
-              "max_failure_ratio": {"type": "number"},
-              "order": {"type": "string", "enum": [
-                "start-first", "stop-first"
-              ]}
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          },
-          "resources": {
-            "type": "object",
-            "properties": {
-              "limits": {
-                "type": "object",
-                "properties": {
-                  "cpus": {"type": ["number", "string"]},
-                  "memory": {"type": "string"},
-                  "pids": {"type": "integer"}
-                },
-                "additionalProperties": false,
-                "patternProperties": {"^x-": {}}
-              },
-              "reservations": {
-                "type": "object",
-                "properties": {
-                  "cpus": {"type": ["number", "string"]},
-                  "memory": {"type": "string"},
-                  "generic_resources": {"$ref": "#/definitions/generic_resources"},
-                  "devices": {"$ref": "#/definitions/devices"}
-                },
-                "additionalProperties": false,
-                "patternProperties": {"^x-": {}}
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          },
-          "restart_policy": {
-            "type": "object",
-            "properties": {
-              "condition": {"type": "string"},
-              "delay": {"type": "string", "format": "duration"},
-              "max_attempts": {"type": "integer"},
-              "window": {"type": "string", "format": "duration"}
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          },
-          "placement": {
-            "type": "object",
-            "properties": {
-              "constraints": {"type": "array", "items": {"type": "string"}},
-              "preferences": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "spread": {"type": "string"}
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {"^x-": {}}
-                }
-              },
-              "max_replicas_per_node": {"type": "integer"}
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          }
-        },
-        "additionalProperties": false,
-        "patternProperties": {"^x-": {}}
-      },
-  
-      "generic_resources": {
-        "id": "#/definitions/generic_resources",
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "discrete_resource_spec": {
-              "type": "object",
-              "properties": {
-                "kind": {"type": "string"},
-                "value": {"type": "number"}
-              },
-              "additionalProperties": false,
-              "patternProperties": {"^x-": {}}
-            }
-          },
-          "additionalProperties": false,
-          "patternProperties": {"^x-": {}}
+
+    "volumes": {
+      "id": "#/properties/volumes",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/volume"
         }
       },
-  
-      "devices": {
-        "id": "#/definitions/devices",
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-              "capabilities": {"$ref": "#/definitions/list_of_strings"},
-              "count": {"type": ["string", "integer"]},
-              "device_ids": {"$ref": "#/definitions/list_of_strings"},
-              "driver":{"type": "string"},
-              "options":{"$ref": "#/definitions/list_or_dict"}
-            },
-          "additionalProperties": false,
-          "patternProperties": {"^x-": {}}
+      "additionalProperties": false
+    },
+
+    "secrets": {
+      "id": "#/properties/secrets",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/secret"
         }
       },
-  
-      "network": {
-        "id": "#/definitions/network",
-        "type": ["object", "null"],
-        "properties": {
-          "name": {"type": "string"},
-          "driver": {"type": "string"},
-          "driver_opts": {
-            "type": "object",
-            "patternProperties": {
-              "^.+$": {"type": ["string", "number"]}
-            }
-          },
-          "ipam": {
-            "type": "object",
-            "properties": {
-              "driver": {"type": "string"},
-              "config": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "subnet": {"type": "string", "format": "subnet_ip_address"},
-                    "ip_range": {"type": "string"},
-                    "gateway": {"type": "string"},
-                    "aux_addresses": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "patternProperties": {"^.+$": {"type": "string"}}
-                    }
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {"^x-": {}}
-                }
-              },
-              "options": {
-                "type": "object",
-                "additionalProperties": false,
-                "patternProperties": {"^.+$": {"type": "string"}}
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          },
-          "external": {
-            "type": ["boolean", "object"],
-            "properties": {
-              "name": {
-                "deprecated": true,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          },
-          "internal": {"type": "boolean"},
-          "enable_ipv6": {"type": "boolean"},
-          "attachable": {"type": "boolean"},
-          "labels": {"$ref": "#/definitions/list_or_dict"}
-        },
-        "additionalProperties": false,
-        "patternProperties": {"^x-": {}}
+      "additionalProperties": false
+    },
+
+    "configs": {
+      "id": "#/properties/configs",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/config"
+        }
       },
-  
-      "volume": {
-        "id": "#/definitions/volume",
-        "type": ["object", "null"],
-        "properties": {
-          "name": {"type": "string"},
-          "driver": {"type": "string"},
-          "driver_opts": {
-            "type": "object",
-            "patternProperties": {
-              "^.+$": {"type": ["string", "number"]}
-            }
-          },
-          "external": {
-            "type": ["boolean", "object"],
-            "properties": {
-              "name": {
-                "deprecated": true,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {"^x-": {}}
-          },
-          "labels": {"$ref": "#/definitions/list_or_dict"}
-        },
-        "additionalProperties": false,
-        "patternProperties": {"^x-": {}}
-      },
-  
-      "secret": {
-        "id": "#/definitions/secret",
-        "type": "object",
-        "properties": {
-          "name": {"type": "string"},
-          "environment": {"type": "string"},
-          "file": {"type": "string"},
-          "external": {
-            "type": ["boolean", "object"],
-            "properties": {
-              "name": {"type": "string"}
-            }
-          },
-          "labels": {"$ref": "#/definitions/list_or_dict"},
-          "driver": {"type": "string"},
-          "driver_opts": {
-            "type": "object",
-            "patternProperties": {
-              "^.+$": {"type": ["string", "number"]}
-            }
-          },
-          "template_driver": {"type": "string"}
-        },
-        "additionalProperties": false,
-        "patternProperties": {"^x-": {}}
-      },
-  
-      "config": {
-        "id": "#/definitions/config",
-        "type": "object",
-        "properties": {
-          "name": {"type": "string"},
-          "file": {"type": "string"},
-          "external": {
-            "type": ["boolean", "object"],
-            "properties": {
-              "name": {
-                "deprecated": true,
-                "type": "string"
-              }
-            }
-          },
-          "labels": {"$ref": "#/definitions/list_or_dict"},
-          "template_driver": {"type": "string"}
-        },
-        "additionalProperties": false,
-        "patternProperties": {"^x-": {}}
-      },
-  
-      "command": {
-        "oneOf": [
-          {"type": "null"},
-          {"type": "string"},
-          {"type": "array","items": {"type": "string"}}
-        ]
-      },
-  
-      "string_or_list": {
-        "oneOf": [
-          {"type": "string"},
-          {"$ref": "#/definitions/list_of_strings"}
-        ]
-      },
-  
-      "list_of_strings": {
-        "type": "array",
-        "items": {"type": "string"},
-        "uniqueItems": true
-      },
-  
-      "list_or_dict": {
-        "oneOf": [
-          {
-            "type": "object",
-            "patternProperties": {
-              ".+": {
-                "type": ["string", "number", "boolean", "null"]
-              }
-            },
-            "additionalProperties": false
-          },
-          {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-        ]
-      },
-  
-      "blkio_limit": {
-        "type": "object",
-        "properties": {
-          "path": {"type": "string"},
-          "rate": {"type": ["integer", "string"]}
-        },
-        "additionalProperties": false
-      },
-      "blkio_weight": {
-        "type": "object",
-        "properties": {
-          "path": {"type": "string"},
-          "weight": {"type": "integer"}
-        },
-        "additionalProperties": false
-      },
-  
-      "service_config_or_secret": {
-        "type": "array",
-        "items": {
+      "additionalProperties": false
+    }
+  },
+
+  "patternProperties": {"^x-": {}},
+  "additionalProperties": false,
+
+  "definitions": {
+
+    "service": {
+      "id": "#/definitions/service",
+      "type": "object",
+
+      "properties": {
+        "develop": {"$ref": "#/definitions/development"},
+        "deploy": {"$ref": "#/definitions/deployment"},
+        "annotations": {"$ref": "#/definitions/list_or_dict"},
+        "attach": {"type": ["boolean", "string"]},
+        "build": {
           "oneOf": [
             {"type": "string"},
             {
               "type": "object",
               "properties": {
-                "source": {"type": "string"},
+                "context": {"type": "string"},
+                "dockerfile": {"type": "string"},
+                "dockerfile_inline": {"type": "string"},
+                "entitlements": {"type": "array", "items": {"type": "string"}},
+                "args": {"$ref": "#/definitions/list_or_dict"},
+                "ssh": {"$ref": "#/definitions/list_or_dict"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
+                "cache_from": {"type": "array", "items": {"type": "string"}},
+                "cache_to": {"type": "array", "items": {"type": "string"}},
+                "no_cache": {"type": ["boolean", "string"]},
+                "additional_contexts": {"$ref": "#/definitions/list_or_dict"},
+                "network": {"type": "string"},
+                "pull": {"type": ["boolean", "string"]},
                 "target": {"type": "string"},
-                "uid": {"type": "string"},
-                "gid": {"type": "string"},
-                "mode": {"type": "number"}
+                "shm_size": {"type": ["integer", "string"]},
+                "extra_hosts": {"$ref": "#/definitions/extra_hosts"},
+                "isolation": {"type": "string"},
+                "privileged": {"type": ["boolean", "string"]},
+                "secrets": {"$ref": "#/definitions/service_config_or_secret"},
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "ulimits": {"$ref": "#/definitions/ulimits"},
+                "platforms": {"type": "array", "items": {"type": "string"}}
               },
               "additionalProperties": false,
               "patternProperties": {"^x-": {}}
             }
           ]
+        },
+        "blkio_config": {
+          "type": "object",
+          "properties": {
+            "device_read_bps": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_read_iops": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_write_bps": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_write_iops": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "weight": {"type": ["integer", "string"]},
+            "weight_device": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_weight"}
+            }
+          },
+          "additionalProperties": false
+        },
+        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cgroup": {"type": "string", "enum": ["host", "private"]},
+        "cgroup_parent": {"type": "string"},
+        "command": {"$ref": "#/definitions/command"},
+        "configs": {"$ref": "#/definitions/service_config_or_secret"},
+        "container_name": {"type": "string"},
+        "cpu_count": {"oneOf": [
+          {"type": "string"},
+          {"type": "integer", "minimum": 0}
+        ]},
+        "cpu_percent": {"oneOf": [
+          {"type": "string"},
+          {"type": "integer", "minimum": 0, "maximum": 100}
+        ]},
+        "cpu_shares": {"type": ["number", "string"]},
+        "cpu_quota": {"type": ["number", "string"]},
+        "cpu_period": {"type": ["number", "string"]},
+        "cpu_rt_period": {"type": ["number", "string"]},
+        "cpu_rt_runtime": {"type": ["number", "string"]},
+        "cpus": {"type": ["number", "string"]},
+        "cpuset": {"type": "string"},
+        "credential_spec": {
+          "type": "object",
+          "properties": {
+            "config": {"type": "string"},
+            "file": {"type": "string"},
+            "registry": {"type": "string"}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "depends_on": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "patternProperties": {"^x-": {}},
+                  "properties": {
+                    "restart": {"type": ["boolean", "string"]},
+                    "required": {
+                      "type":  "boolean",
+                      "default": true
+                    },
+                    "condition": {
+                      "type": "string",
+                      "enum": ["service_started", "service_healthy", "service_completed_successfully"]
+                    }
+                  },
+                  "required": ["condition"]
+                }
+              }
+            }
+          ]
+        },
+        "device_cgroup_rules": {"$ref": "#/definitions/list_of_strings"},
+        "devices": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "required": ["source"],
+                "properties": {
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "permissions": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          }
+        },
+        "dns": {"$ref": "#/definitions/string_or_list"},
+        "dns_opt": {"type": "array","items": {"type": "string"}, "uniqueItems": true},
+        "dns_search": {"$ref": "#/definitions/string_or_list"},
+        "domainname": {"type": "string"},
+        "entrypoint": {"$ref": "#/definitions/command"},
+        "env_file": {"$ref": "#/definitions/env_file"},
+        "label_file": {"$ref": "#/definitions/label_file"},
+        "environment": {"$ref": "#/definitions/list_or_dict"},
+
+        "expose": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"],
+            "format": "expose"
+          },
+          "uniqueItems": true
+        },
+        "extends": {
+          "oneOf": [
+            {"type": "string"},
+            {
+              "type": "object",
+
+              "properties": {
+                "service": {"type": "string"},
+                "file": {"type": "string"}
+              },
+              "required": ["service"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "extra_hosts": {"$ref": "#/definitions/extra_hosts"},
+        "gpus": {"$ref": "#/definitions/gpus"},
+        "group_add": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"]
+          },
+          "uniqueItems": true
+        },
+        "healthcheck": {"$ref": "#/definitions/healthcheck"},
+        "hostname": {"type": "string"},
+        "image": {"type": "string"},
+        "init": {"type": ["boolean", "string"]},
+        "ipc": {"type": "string"},
+        "isolation": {"type": "string"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "logging": {
+          "type": "object",
+
+          "properties": {
+            "driver": {"type": "string"},
+            "options": {
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {"type": ["string", "number", "null"]}
+              }
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "mac_address": {"type": "string"},
+        "mem_limit": {"type": ["number", "string"]},
+        "mem_reservation": {"type": ["string", "integer"]},
+        "mem_swappiness": {"type": ["integer", "string"]},
+        "memswap_limit": {"type": ["number", "string"]},
+        "network_mode": {"type": "string"},
+        "networks": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "aliases": {"$ref": "#/definitions/list_of_strings"},
+                        "ipv4_address": {"type": "string"},
+                        "ipv6_address": {"type": "string"},
+                        "link_local_ips": {"$ref": "#/definitions/list_of_strings"},
+                        "mac_address": {"type": "string"},
+                        "driver_opts": {
+                          "type": "object",
+                          "patternProperties": {
+                            "^.+$": {"type": ["string", "number"]}
+                          }
+                        },
+                        "priority": {"type": "number"}
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {"^x-": {}}
+                    },
+                    {"type": "null"}
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "oom_kill_disable": {"type": ["boolean", "string"]},
+        "oom_score_adj": {"oneOf": [
+          {"type": "string"},
+          {"type": "integer", "minimum": -1000, "maximum": 1000}
+        ]},
+        "pid": {"type": ["string", "null"]},
+        "pids_limit": {"type": ["number", "string"]},
+        "platform": {"type": "string"},
+        "ports": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "number"},
+              {"type": "string"},
+              {
+                "type": "object",
+                "properties": {
+                  "name": {"type": "string"},
+                  "mode": {"type": "string"},
+                  "host_ip": {"type": "string"},
+                  "target": {"type": ["integer", "string"]},
+                  "published": {"type": ["string", "integer"]},
+                  "protocol": {"type": "string"},
+                  "app_protocol": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "post_start": {"type": "array", "items": {"$ref": "#/definitions/service_hook"}},
+        "pre_stop": {"type": "array", "items": {"$ref": "#/definitions/service_hook"}},
+        "privileged": {"type": ["boolean", "string"]},
+        "profiles": {"$ref": "#/definitions/list_of_strings"},
+        "pull_policy": {"type": "string", "enum": [
+          "always", "never", "if_not_present", "build", "missing"
+        ]},
+        "read_only": {"type": ["boolean", "string"]},
+        "restart": {"type": "string"},
+        "runtime": {
+          "type": "string"
+        },
+        "scale": {
+          "type": ["integer", "string"]
+        },
+        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "shm_size": {"type": ["number", "string"]},
+        "secrets": {"$ref": "#/definitions/service_config_or_secret"},
+        "sysctls": {"$ref": "#/definitions/list_or_dict"},
+        "stdin_open": {"type": ["boolean", "string"]},
+        "stop_grace_period": {"type": "string"},
+        "stop_signal": {"type": "string"},
+        "storage_opt": {"type": "object"},
+        "tmpfs": {"$ref": "#/definitions/string_or_list"},
+        "tty": {"type": ["boolean", "string"]},
+        "ulimits": {"$ref": "#/definitions/ulimits"},
+        "user": {"type": "string"},
+        "uts": {"type": "string"},
+        "userns_mode": {"type": "string"},
+        "volumes": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {"type": "string"},
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "read_only": {"type": ["boolean", "string"]},
+                  "consistency": {"type": "string"},
+                  "bind": {
+                    "type": "object",
+                    "properties": {
+                      "propagation": {"type": "string"},
+                      "create_host_path": {"type": ["boolean", "string"]},
+                      "recursive": {"type": "string", "enum": ["enabled", "disabled", "writable", "readonly"]},
+                      "selinux": {"type": "string", "enum": ["z", "Z"]}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "volume": {
+                    "type": "object",
+                    "properties": {
+                      "nocopy": {"type": ["boolean", "string"]},
+                      "subpath": {"type": "string"}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "tmpfs": {
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "oneOf": [
+                          {"type": "integer", "minimum": 0},
+                          {"type": "string"}
+                        ]
+                      },
+                      "mode": {"type": ["number", "string"]}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "volumes_from": {
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "working_dir": {"type": "string"}
+      },
+      "patternProperties": {"^x-": {}},
+      "additionalProperties": false
+    },
+
+    "healthcheck": {
+      "id": "#/definitions/healthcheck",
+      "type": "object",
+      "properties": {
+        "disable": {"type": ["boolean", "string"]},
+        "interval": {"type": "string"},
+        "retries": {"type": ["number", "string"]},
+        "test": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "timeout": {"type": "string"},
+        "start_period": {"type": "string"},
+        "start_interval": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+    "development": {
+      "id": "#/definitions/development",
+      "type": ["object", "null"],
+      "properties": {
+        "watch": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["path", "action"],
+            "properties": {
+              "ignore": {"type": "array", "items": {"type": "string"}},
+              "path": {"type": "string"},
+              "action": {"type": "string", "enum": ["rebuild", "sync", "restart", "sync+restart", "sync+exec"]},
+              "target": {"type": "string"},
+              "exec": {"$ref": "#/definitions/service_hook"}
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
+          }
         }
       },
-  
-      "constraints": {
-        "service": {
-          "id": "#/definitions/constraints/service",
-          "anyOf": [
-            {"required": ["build"]},
-            {"required": ["image"]}
-          ],
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+    "deployment": {
+      "id": "#/definitions/deployment",
+      "type": ["object", "null"],
+      "properties": {
+        "mode": {"type": "string"},
+        "endpoint_mode": {"type": "string"},
+        "replicas": {"type": ["integer", "string"]},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "rollback_config": {
+          "type": "object",
           "properties": {
-            "build": {
-              "required": ["context"]
+            "parallelism": {"type": ["integer", "string"]},
+            "delay": {"type": "string"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string"},
+            "max_failure_ratio": {"type": ["number", "string"]},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "update_config": {
+          "type": "object",
+          "properties": {
+            "parallelism": {"type": ["integer", "string"]},
+            "delay": {"type": "string"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string"},
+            "max_failure_ratio": {"type": ["number", "string"]},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpus": {"type": ["number", "string"]},
+                "memory": {"type": "string"},
+                "pids": {"type": ["integer", "string"]}
+              },
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}
+            },
+            "reservations": {
+              "type": "object",
+              "properties": {
+                "cpus": {"type": ["number", "string"]},
+                "memory": {"type": "string"},
+                "generic_resources": {"$ref": "#/definitions/generic_resources"},
+                "devices": {"$ref": "#/definitions/devices"}
+              },
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}
             }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "restart_policy": {
+          "type": "object",
+          "properties": {
+            "condition": {"type": "string"},
+            "delay": {"type": "string"},
+            "max_attempts": {"type": ["integer", "string"]},
+            "window": {"type": "string"}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "placement": {
+          "type": "object",
+          "properties": {
+            "constraints": {"type": "array", "items": {"type": "string"}},
+            "preferences": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "spread": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            },
+            "max_replicas_per_node": {"type": ["integer", "string"]}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "generic_resources": {
+      "id": "#/definitions/generic_resources",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "discrete_resource_spec": {
+            "type": "object",
+            "properties": {
+              "kind": {"type": "string"},
+              "value": {"type": ["number", "string"]}
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
+          }
+        },
+        "additionalProperties": false,
+        "patternProperties": {"^x-": {}}
+      }
+    },
+
+    "devices": {
+      "id": "#/definitions/devices",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "capabilities": {"$ref": "#/definitions/list_of_strings"},
+          "count": {"type": ["string", "integer"]},
+          "device_ids": {"$ref": "#/definitions/list_of_strings"},
+          "driver":{"type": "string"},
+          "options":{"$ref": "#/definitions/list_or_dict"}
+        },
+        "additionalProperties": false,
+        "patternProperties": {"^x-": {}},
+        "required": [
+          "capabilities"
+        ]
+      }
+    },
+
+    "gpus": {
+      "id": "#/definitions/gpus",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "capabilities": {"$ref": "#/definitions/list_of_strings"},
+          "count": {"type": ["string", "integer"]},
+          "device_ids": {"$ref": "#/definitions/list_of_strings"},
+          "driver":{"type": "string"},
+          "options":{"$ref": "#/definitions/list_or_dict"}
+        },
+        "additionalProperties": false,
+        "patternProperties": {"^x-": {}}
+      }
+    },
+
+    "include": {
+      "id": "#/definitions/include",
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "object",
+          "properties": {
+            "path": {"$ref": "#/definitions/string_or_list"},
+            "env_file": {"$ref": "#/definitions/string_or_list"},
+            "project_directory": {"type": "string"}
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+
+    "network": {
+      "id": "#/definitions/network",
+      "type": ["object", "null"],
+      "properties": {
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "ipam": {
+          "type": "object",
+          "properties": {
+            "driver": {"type": "string"},
+            "config": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "subnet": {"type": "string"},
+                  "ip_range": {"type": "string"},
+                  "gateway": {"type": "string"},
+                  "aux_addresses": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "patternProperties": {"^.+$": {"type": "string"}}
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {"^.+$": {"type": "string"}}
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "external": {
+          "type": ["boolean", "string", "object"],
+          "properties": {
+            "name": {
+              "deprecated": true,
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "internal": {"type": ["boolean", "string"]},
+        "enable_ipv6": {"type": ["boolean", "string"]},
+        "attachable": {"type": ["boolean", "string"]},
+        "labels": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "volume": {
+      "id": "#/definitions/volume",
+      "type": ["object", "null"],
+      "properties": {
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "external": {
+          "type": ["boolean", "string", "object"],
+          "properties": {
+            "name": {
+              "deprecated": true,
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "secret": {
+      "id": "#/definitions/secret",
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "environment": {"type": "string"},
+        "file": {"type": "string"},
+        "external": {
+          "type": ["boolean", "string", "object"],
+          "properties": {
+            "name": {"type": "string"}
+          }
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "template_driver": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "config": {
+      "id": "#/definitions/config",
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "content": {"type": "string"},
+        "environment": {"type": "string"},
+        "file": {"type": "string"},
+        "external": {
+          "type": ["boolean", "string", "object"],
+          "properties": {
+            "name": {
+              "deprecated": true,
+              "type": "string"
+            }
+          }
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "template_driver": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "command": {
+      "oneOf": [
+        {"type": "null"},
+        {"type": "string"},
+        {"type": "array","items": {"type": "string"}}
+      ]
+    },
+
+    "service_hook": {
+      "id": "#/definitions/service_hook",
+      "type": "object",
+      "properties": {
+        "command": {"$ref": "#/definitions/command"},
+        "user": {"type": "string"},
+        "privileged": {"type": ["boolean", "string"]},
+        "working_dir": {"type": "string"},
+        "environment": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "env_file": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "format": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": ["boolean", "string"],
+                    "default": true
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+
+    "label_file": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      ]
+    },
+
+    "string_or_list": {
+      "oneOf": [
+        {"type": "string"},
+        {"$ref": "#/definitions/list_of_strings"}
+      ]
+    },
+
+    "list_of_strings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+
+    "list_or_dict": {
+      "oneOf": [
+        {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "type": ["string", "number", "boolean", "null"]
+            }
+          },
+          "additionalProperties": false
+        },
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      ]
+    },
+
+    "extra_hosts": {
+      "oneOf": [
+        {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": false
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      ]
+    },
+
+    "blkio_limit": {
+      "type": "object",
+      "properties": {
+        "path": {"type": "string"},
+        "rate": {"type": ["integer", "string"]}
+      },
+      "additionalProperties": false
+    },
+    "blkio_weight": {
+      "type": "object",
+      "properties": {
+        "path": {"type": "string"},
+        "weight": {"type": ["integer", "string"]}
+      },
+      "additionalProperties": false
+    },
+    "service_config_or_secret": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"type": "string"},
+          {
+            "type": "object",
+            "properties": {
+              "source": {"type": "string"},
+              "target": {"type": "string"},
+              "uid": {"type": "string"},
+              "gid": {"type": "string"},
+              "mode": {"type": ["number", "string"]}
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
+          }
+        ]
+      }
+    },
+    "ulimits": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z]+$": {
+          "oneOf": [
+            {"type": ["integer", "string"]},
+            {
+              "type": "object",
+              "properties": {
+                "hard": {"type": ["integer", "string"]},
+                "soft": {"type": ["integer", "string"]}
+              },
+              "required": ["soft", "hard"],
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}
+            }
+          ]
+        }
+      }
+    },
+    "constraints": {
+      "service": {
+        "id": "#/definitions/constraints/service",
+        "anyOf": [
+          {"required": ["build"]},
+          {"required": ["image"]}
+        ],
+        "properties": {
+          "build": {
+            "required": ["context"]
           }
         }
       }
     }
   }
+}

--- a/tests/services/test_compose_schema.yml
+++ b/tests/services/test_compose_schema.yml
@@ -3,7 +3,7 @@
 - name: Perform Lookup for {{ item }} File
   ansible.builtin.set_fact:
     compose_service_file: "{{ lookup('ansible.builtin.file', '{{ item }}') | from_yaml }}"
-    compose_spec_schema: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/schemas/compose-spec.json') }}"
+    compose_spec_schema: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/schemas/compose-spec-v2.json') }}"
 
 - name: Perform Validation for Compose File with compose-spec JSONSchema
   ansible.builtin.set_fact:

--- a/tests/services/test_compose_schema.yml
+++ b/tests/services/test_compose_schema.yml
@@ -3,7 +3,7 @@
 - name: Perform Lookup for {{ item }} File
   ansible.builtin.set_fact:
     compose_service_file: "{{ lookup('ansible.builtin.file', '{{ item }}') | from_yaml }}"
-    compose_spec_schema: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/schemas/compose-spec-v2.json') }}"
+    compose_spec_schema: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/schemas/compose-spec.json') }}"
 
 - name: Perform Validation for Compose File with compose-spec JSONSchema
   ansible.builtin.set_fact:

--- a/tests/test_generated_files.yml
+++ b/tests/test_generated_files.yml
@@ -36,18 +36,18 @@
           loop_control:
             label: "{{ item.item }}"
 
-    - name: Check for Deployment-Ready docker-compose.yml File
+    - name: Check for Deployment-Ready compose.yml File
       block:
-        - name: Get stats for Deployment-Ready docker-compose.yml file
+        - name: Get stats for Deployment-Ready compose.yml file
           ansible.builtin.stat:
-            path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/docker-compose.yml"
+            path: "{{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }}/compose.yml"
           register: test_compose_deployment_file_stat
 
-        - name: Check if docker-compose.yml File exist
+        - name: Check if compose.yml File exist
           ansible.builtin.assert:
             that: test_compose_deployment_file_stat.stat.exists and test_compose_deployment_file_stat.stat.mode == '0644'
-            fail_msg: "FAIL: docker-compose.yml DOES NOT exist in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
-            success_msg: "PASS: docker-compose.yml File exists in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
+            fail_msg: "FAIL: compose.yml DOES NOT exist in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
+            success_msg: "PASS: compose.yml File exists in {{ komponist.deploy_dir | default(ansible_user_dir + '/.komponist') }} directory."
 
     - name: Check Mosquitto MQTT Generated Files in deploy_dir
       ansible.builtin.include_tasks: "{{ playbook_dir }}/services/test_config_mosquitto.yml"


### PR DESCRIPTION
instead of generating a compose file from `docker compose config` use the compose files as if they are headers and they are included in an entrypoint `compose.yml` file.

adapt the jsonschema file for tests.

closes #120